### PR TITLE
Improve Stereo Error Clarity

### DIFF
--- a/scripts/wavReader.js
+++ b/scripts/wavReader.js
@@ -145,9 +145,20 @@ function readGeneralHeader (buffer, fileSize) {
         header.wavFormat.bytesPerCapture = readUInt16LE(state);
         header.wavFormat.bitsPerSample = readUInt16LE(state);
 
+        if (header.wavFormat.numberOfChannels !== NUMBER_OF_CHANNELS) {
+
+            showWAVFormat(header.wavFormat);
+
+            return {
+                success: false,
+                error: 'Invalid number of channels, you must mix down to mono.'
+            };
+
+        }
+
         const formatValid = header.wavFormat.format === PCM_WAV_FORMAT || header.wavFormat.format === EXTENSIBLE_WAV_FORMAT;
 
-        if (!formatValid || header.wavFormat.numberOfChannels !== NUMBER_OF_CHANNELS || header.wavFormat.bytesPerSecond !== NUMBER_OF_BYTES_IN_SAMPLE * header.wavFormat.samplesPerSecond || header.wavFormat.bytesPerCapture !== NUMBER_OF_BYTES_IN_SAMPLE || header.wavFormat.bitsPerSample !== NUMBER_OF_BITS_IN_SAMPLE) {
+        if (!formatValid || header.wavFormat.bytesPerSecond !== NUMBER_OF_BYTES_IN_SAMPLE * header.wavFormat.samplesPerSecond || header.wavFormat.bytesPerCapture !== NUMBER_OF_BYTES_IN_SAMPLE || header.wavFormat.bitsPerSample !== NUMBER_OF_BITS_IN_SAMPLE) {
 
             showWAVFormat(header.wavFormat);
 


### PR DESCRIPTION
A simple fix until stereo-to-mono mix down is supported is to just improve clarity of error messages so users are made aware that they should mix their own mono file in Audacity or whatever.

I assume this might also fix #2 as it's a likely reason that a WAV file will fail.

I also tried to look into fixing this properly by reading a stereo WAV file and then mixing it down, but you are using a custom WAV decoder that seems to expect mono only, and I'm not too familiar with the spec. Have you considered using a more generic WAV decoder that supports a very wide range of features, and then mixing things down from the resulting sample data? This would clean up your code quite a bit as it can look like this:

```js
import wav from 'node-wav';

const {
  sampleRate,
  channelData
} = await wav.decode(fileArrayBuffer);

// now convert the channelData + sampleRate to your desired format
const newAudioBuffer = convertToExpectedFormat(...);
```

I have 32-bit float WAV files that I'd like to pass through AudioMoth-Play, and even with stereo-to-mono mixdown it would not work right now.

Here's an open source decoder that might be a suitable dependency:
https://www.npmjs.com/package/node-wav